### PR TITLE
Fixing find exiv2 in manjaro

### DIFF
--- a/cmake/FindExiv2.cmake
+++ b/cmake/FindExiv2.cmake
@@ -70,6 +70,21 @@ if(EXIV2_INCLUDE_DIR  AND NOT  EXIV2_VERSION)
   set(EXIV2_VERSION "${EXIV2_VERSION_MAJOR}.${EXIV2_VERSION_MINOR}.${EXIV2_VERSION_PATCH}" CACHE STRING "Version number of Exiv2" FORCE)
 endif(EXIV2_INCLUDE_DIR  AND NOT  EXIV2_VERSION)
 
+#In some systems the version number is in the exv_conf.h and not in version.hpp. So we have to try again if we do not find in the first try
+if("${EXIV2_VERSION}" STREQUAL "..")
+  file(READ ${EXIV2_INCLUDE_DIR}/exiv2/exv_conf.h EXIV2_VERSION_CONTENT)
+  string(REGEX MATCH "#define EXIV2_MAJOR_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
+  set(EXIV2_VERSION_MAJOR "${CMAKE_MATCH_1}")
+
+  string(REGEX MATCH "#define EXIV2_MINOR_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
+  set(EXIV2_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+  string(REGEX MATCH "#define EXIV2_PATCH_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
+  set(EXIV2_VERSION_PATCH "${CMAKE_MATCH_1}")
+
+  set(EXIV2_VERSION "${EXIV2_VERSION_MAJOR}.${EXIV2_VERSION_MINOR}.${EXIV2_VERSION_PATCH}" CACHE STRING "Version number of Exiv2" FORCE)
+endif()
+
 set(EXIV2_LIBRARIES "${EXIV2_LIBRARY}")
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
In manjaro, FindExiv2.cmake fails to find the library version. This commit fixes this problem.